### PR TITLE
Update to work with GORM v1.22+

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -10,7 +10,7 @@ func initializeCallbacks(db *gorm.DB) {
 
 	// register callbacks
 	callbacks.RegisterDefaultCallbacks(db, &callbacks.Config{
-		WithReturning: true,
+		CreateClauses: []string{"RETURNING"},
 	})
 
 	c := &bigQueryCallbacks{db}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested * (see below)

### What did this pull request do?

A [recent refactor](https://github.com/go-gorm/gorm/commit/af3fbdc2fcfface01ce2a0795ee0fac3997ddc8e) broke BigQuery support in a big way by moving a `callback.Config` option into another. This commit updates the driver to use the new `callback.Config` option instead.

### * Why No Testing?

The tests, as written here, _cannot be run locally_ by anyone without the same creds used by the project creator. The refactor needed to fix this is beyond the scope of the change being introduced by so much that it wasn't actually made, here. Please run the tests with the correct creds before merging.