### PR TITLE
Add scopes option support

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -43,31 +44,38 @@ func (b bigQueryDriver) Open(uri string) (driver.Conn, error) {
 }
 
 func configFromUri(uri string) (*bigQueryConfig, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, invalidConnectionStringError(uri)
+	}
 
-	if !strings.HasPrefix(uri, "bigquery://") {
+	if u.Scheme != "bigquery" {
 		return nil, fmt.Errorf("invalid prefix, expected bigquery:// got: %s", uri)
 	}
 
-	uri = strings.ToLower(uri)
-	path := strings.TrimPrefix(uri, "bigquery://")
-	fields := strings.Split(path, "/")
+	if u.Path == "" {
+		return nil, invalidConnectionStringError(uri)
+	}
 
-	if len(fields) == 3 {
-		return &bigQueryConfig{
-			projectID: fields[0],
-			location:  fields[1],
-			dataSet:   fields[2],
-		}, nil
+	fields := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
+	if len(fields) > 2 {
+		return nil, invalidConnectionStringError(uri)
+	}
+
+	config := &bigQueryConfig{
+		projectID: u.Hostname(),
+		dataSet:   fields[len(fields)-1],
 	}
 
 	if len(fields) == 2 {
-		return &bigQueryConfig{
-			projectID: fields[0],
-			location:  "",
-			dataSet:   fields[1],
-		}, nil
+		config.location = fields[0]
 	}
+
+	return config, nil
+}
 
 	return nil, fmt.Errorf("invalid connection string : %s", uri)
 
+func invalidConnectionStringError(uri string) error {
+	return fmt.Errorf("invalid connection string: %s", uri)
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?


- Add support to authenticate using scopes.
  - Refactor the existing method that parses the URI to be parsed by using the `net/url` library.
  - Use the [WithScopes() option ](https://pkg.go.dev/google.golang.org/api/option#WithScopes)to create the [bigquery client.](https://pkg.go.dev/cloud.google.com/go/bigquery#NewClient)
  - The scopes will be included as optional in the connection string as follows: `bigquery://project_id/dataset?scopes=scope1,scope2,scope3`
- No breaking changes have been introduced:
  - The `configFromURI()` function has been refactored to meet the same behavior as before.
  - The scopes in the URI string can be added as optional without affecting the current behavior if the query parameter is not present.


### User Case Description

Being able to authenticate the bigquery client by passing [OAuth2 scopes](https://developers.google.com/identity/protocols/oauth2/scopes) received in the `uri`.

Some examples of valid connection strings:
```
"bigquery://project-id/location/dataset?scopes=https://www.googleapis.com/auth/drive,https://www.googleapis.com/auth/bigquery"

"bigquery://bigquery-credits/dataset?scopes=https://www.googleapis.com/auth/drive,https://www.googleapis.com/auth/bigquery"

"bigquery://bigquery-credits/location/dataset"

"bigquery://bigquery-credits/dataset"
```