### PR TITLE
Add support for marshalling complex types to JSON

### DIFF
--- a/driver/columns.go
+++ b/driver/columns.go
@@ -1,8 +1,10 @@
 package driver
 
 import (
-	"cloud.google.com/go/bigquery"
 	"database/sql/driver"
+	"encoding/json"
+
+	"cloud.google.com/go/bigquery"
 	"gorm.io/driver/bigquery/adaptor"
 )
 
@@ -32,6 +34,10 @@ func (columns bigQueryColumns) ColumnNames() []string {
 type bigQueryReroutedColumn struct {
 	values []bigquery.Value
 	schema bigquery.Schema
+}
+
+func (c bigQueryReroutedColumn) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.values)
 }
 
 type bigQueryColumn struct {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

When using this package in [vanilla *sql.DB mode](https://github.com/go-gorm/bigquery#vanilla-sqldb-usage), row element values corresponding to complex type columns are wrapped in `bigQueryReroutedColumn` struct instances, which, unfortunately, doesn't play nice with [`json.Marshal`](https://pkg.go.dev/encoding/json#Marshal).

### User Case Description

<!-- Your use case -->

For example, if I create a table `CREATE TABLE FOOBAR(x INT64, y STRUCT<a ARRAY<STRING>, b BOOL>)` and I insert a row `INSERT INTO FOOBAR.FOO(x,y) VALUES (5, (['foo','bar','baz'], true))` and I run this code:

```golang
package main

import (
	"database/sql"
	"encoding/json"
	"fmt"

	_ "gorm.io/driver/bigquery/driver"
)

func main() {
	db, err := sql.Open("bigquery", "bigquery://go-bigquery-driver/playground")
	if err != nil {
		panic(err)
	}
	defer db.Close()

	row := db.QueryRow("SELECT y FROM FOOBAR.FOO")
	var data any
	switch err := row.Scan(&data); err {
	case sql.ErrNoRows:
		fmt.Println("No rows were returned!")
	case nil:
		bytes, err := json.Marshal(data)
		if err != nil {
			panic(err)
		}
		fmt.Println(string(bytes))
	default:
		panic(err)
	}
}
```

I get `{}` as output. However, with the extra `MarshalJSON` that I introduced in this PR, the output becomes `[["foo","bar","baz"],true]`.

Please note that I'm not super-experienced with writing database drivers for Go, so I'm not sure if this is the best way to address this issue, but it looks like the simplest.

Also, if you're interested in having an automated test suite for this via GitHub Actions which run https://github.com/goccy/bigquery-emulator in a sidecar container, I could put in some time to add it. Unfortunately, this emulator doesn't currently have `INFORMATION_SCHEMA` support (see https://github.com/goccy/bigquery-emulator/issues/48), so the existing tests which make use of `HasTable()` won't work. It will still be possible to write new tests which don't make use of that feature.