### PR TITLE
Support using Credentials JSON to connect to BigQuery

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"context"
 	"database/sql/driver"
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"strings"
@@ -22,6 +23,7 @@ type bigQueryConfig struct {
 	endpoint       string
 	disableAuth    bool
 	credentialFile string
+	credentialJSON string
 }
 
 func (b bigQueryDriver) Open(uri string) (driver.Conn, error) {
@@ -45,6 +47,9 @@ func (b bigQueryDriver) Open(uri string) (driver.Conn, error) {
 	}
 	if config.credentialFile != "" {
 		opts = append(opts, option.WithCredentialsFile(config.credentialFile))
+	}
+	if config.credentialJSON != "" {
+		opts = append(opts, option.WithCredentialsJSON([]byte(config.credentialJSON)))
 	}
 
 	client, err := bigquery.NewClient(ctx, config.projectID, opts...)
@@ -85,6 +90,15 @@ func configFromUri(uri string) (*bigQueryConfig, error) {
 		endpoint:       u.Query().Get("endpoint"),
 		disableAuth:    u.Query().Get("disable_auth") == "true",
 		credentialFile: u.Query().Get("credential_file"),
+	}
+
+	if u.Query().Get("credential_json") != nil {
+		credentialsJSON, err := base64.StdEncoding.DecodeString(u.Query().Get("credential_json"))
+		if err != nil {
+			return nil, err
+		} else {
+			config.credentialJSON = credentialsJSON
+		}
 	}
 
 	if len(fields) == 2 {


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested

### What did this pull request do?

Adds support for `WithCredentialsJSON` (see [Google docs](https://pkg.go.dev/google.golang.org/api/option#WithCredentialsJSON)) instead of requiring a credentials file.  

This helps provide a way to limit credentials living on disk/in long-lived files.

Expects a base64 encoded credentials file passed in as a URL query parameter.

### User Case Description

We don't store credentials on disk and but still want a way to explicitly pass them to the underlying Go driver for connecting to BigQuery.
