### PR TITLE
Implement missing CheckNamedValue function

### DIFF
--- a/driver/connection.go
+++ b/driver/connection.go
@@ -1,10 +1,11 @@
 package driver
 
 import (
-	"cloud.google.com/go/bigquery"
 	"context"
 	"database/sql/driver"
 	"fmt"
+
+	"cloud.google.com/go/bigquery"
 )
 
 type bigQueryConnection struct {
@@ -94,7 +95,6 @@ func (connection *bigQueryConnection) Exec(query string, args []driver.Value) (d
 	return statement.Exec(args)
 }
 
-func (bigQueryConnection) CheckNamedValue(*driver.NamedValue) error {
-	// TODO: Revise in the future
-	return nil
+func (connection *bigQueryConnection) CheckNamedValue(namedValue *driver.NamedValue) error {
+	return unwrapValuer(namedValue)
 }

--- a/driver/statement.go
+++ b/driver/statement.go
@@ -22,8 +22,8 @@ func (statement bigQueryStatement) NumInput() int {
 	return 0
 }
 
-func (bigQueryStatement) CheckNamedValue(*driver.NamedValue) error {
-	return nil
+func (bigQueryStatement) CheckNamedValue(namedValue *driver.NamedValue) error {
+	return unwrapValuer(namedValue)
 }
 
 func (statement *bigQueryStatement) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {

--- a/driver/valuer.go
+++ b/driver/valuer.go
@@ -1,0 +1,28 @@
+package driver
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+const maxValuerUnwrapDepth = 100
+
+func unwrapValuer(namedValue *driver.NamedValue) error {
+	value := namedValue.Value
+	for depth := 0; depth < maxValuerUnwrapDepth; depth++ {
+		valuer, ok := value.(driver.Valuer)
+		if !ok {
+			namedValue.Value = value
+			return nil
+		}
+
+		unwrapped, err := valuer.Value()
+		if err != nil {
+			return err
+		}
+
+		value = unwrapped
+	}
+
+	return fmt.Errorf("valuer unwrap exceeded max depth %d", maxValuerUnwrapDepth)
+}

--- a/driver/valuer_test.go
+++ b/driver/valuer_test.go
@@ -1,0 +1,64 @@
+package driver
+
+import (
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type staticValuer struct {
+	value driver.Value
+}
+
+func (valuer staticValuer) Value() (driver.Value, error) {
+	return valuer.value, nil
+}
+
+type errorValuer struct {
+	err error
+}
+
+func (valuer errorValuer) Value() (driver.Value, error) {
+	return nil, valuer.err
+}
+
+type recursiveValuer struct{}
+
+func (recursiveValuer) Value() (driver.Value, error) {
+	return recursiveValuer{}, nil
+}
+
+func TestBigQueryConnectionCheckNamedValueUnwrapsNestedValuer(t *testing.T) {
+	namedValue := &driver.NamedValue{
+		Name:  "value",
+		Value: staticValuer{value: staticValuer{value: "hello"}},
+	}
+
+	err := bigQueryConnection{}.CheckNamedValue(namedValue)
+
+	require.NoError(t, err)
+	require.Equal(t, "hello", namedValue.Value)
+}
+
+func TestBigQueryStatementCheckNamedValuePropagatesValuerError(t *testing.T) {
+	expectedErr := errors.New("fail to unwrap")
+	namedValue := &driver.NamedValue{
+		Value: errorValuer{err: expectedErr},
+	}
+
+	err := bigQueryStatement{}.CheckNamedValue(namedValue)
+
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestBigQueryStatementCheckNamedValueGuardsAgainstInfiniteUnwrap(t *testing.T) {
+	namedValue := &driver.NamedValue{
+		Value: recursiveValuer{},
+	}
+
+	err := bigQueryStatement{}.CheckNamedValue(namedValue)
+
+	require.EqualError(t, err, "valuer unwrap exceeded max depth 100")
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Implement missing CheckNamedValue function to prevent recursion exception when using custom serializer. It's not implemented right now.

### User Case Description

We use a custom serializer to convert time.Time to civil.DateTime, but bigquery throws stackoverflow due to lack of serialization for custom valuer methods
