### PR TITLE
Remove invalid bigquery create callbacks

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -10,7 +10,7 @@ func initializeCallbacks(db *gorm.DB) {
 
 	// register callbacks
 	callbacks.RegisterDefaultCallbacks(db, &callbacks.Config{
-		CreateClauses: []string{"INSERT", "VALUES", "ON CONFLICT", "RETURNING"},
+		CreateClauses: []string{"INSERT", "VALUES"},
 	})
 
 	c := &bigQueryCallbacks{db}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

BigQuery does not support `ON CONFLICT` nor `RETURNING`. Thus it should not be available for the gorm create callbacks.
```
googleapi: Error 400: Syntax error: Expected end of input but got identifier "RETURNING" at [1:266], invalidQuery
[235.079ms] [rows:0] INSERT INTO `Segments` (`id`,`name`,`value`,`...`) VALUES (?,?,?,...) RETURNING `...`
```

<img width="630" height="84" alt="image" src="https://github.com/user-attachments/assets/2481857a-79c9-46a1-a4c3-5934b1a25cf9" />



### User Case Description

gorm currently tries to include ON CONFLICT when saving/updating partial structs